### PR TITLE
Removed TextureViewDimension init (dawn does this).

### DIFF
--- a/generator/templates/binding-gyp.njk
+++ b/generator/templates/binding-gyp.njk
@@ -75,7 +75,10 @@
               "<(dawn)/third_party/vulkan-headers/include",
               "<(root)/lib/include",
               "<(dawn)/src/include",
-              "<(dawn)/out/Shared/gen/src/include"
+              "<(dawn)/out/Shared/gen/src/include",
+              "<(dawn)/third_party/shaderc/libshaderc/include",
+              "<(dawn)/third_party/shaderc/libshaderc/src/shaderc.cc",
+              "<(dawn)/third_party/shaderc/libshaderc/src/shaderc_private.h"
             ],
             "cflags": [
               "-std=c++14",

--- a/src/GPUTextureView.cpp
+++ b/src/GPUTextureView.cpp
@@ -23,29 +23,6 @@ GPUTextureView::GPUTextureView(const Napi::CallbackInfo& info) : Napi::ObjectWra
 
   Napi::Object opts = info[1].As<Napi::Object>();
 
-  // if dimension is unspecified, do:
-  // https://gpuweb.github.io/gpuweb/#texture-view-creation
-  if (!(opts.Has("dimension"))) {
-    WGPUTextureDimension srcDimension = texture->dimension;
-    WGPUTextureViewDimension dstDimension = WGPUTextureViewDimension_Undefined;
-    switch (srcDimension) {
-      case WGPUTextureDimension_1D: {
-        dstDimension = WGPUTextureViewDimension_1D;
-      } break;
-      case WGPUTextureDimension_2D: {
-        if (texture->arrayLayerCount > 1 && (&descriptor)->arrayLayerCount == 0) {
-          dstDimension = WGPUTextureViewDimension_2DArray;
-        } else {
-          dstDimension = WGPUTextureViewDimension_2D;
-        }
-      } break;
-      case WGPUTextureDimension_3D: {
-        dstDimension = WGPUTextureViewDimension_3D;
-      } break;
-    };
-    (&descriptor)->dimension = dstDimension;
-  }
-
   this->instance = wgpuTextureCreateView(texture->instance, &descriptor);
 }
 

--- a/src/GPUTextureView.cpp
+++ b/src/GPUTextureView.cpp
@@ -21,8 +21,6 @@ GPUTextureView::GPUTextureView(const Napi::CallbackInfo& info) : Napi::ObjectWra
 
   auto descriptor = DescriptorDecoder::GPUTextureViewDescriptor(device, info[1].As<Napi::Value>());
 
-  Napi::Object opts = info[1].As<Napi::Object>();
-
   this->instance = wgpuTextureCreateView(texture->instance, &descriptor);
 }
 


### PR DESCRIPTION
Removed init for TextureViewDimension from GPUTexutureView.cpp
Dawn initializes this internally and doing it from NAPI was not advised.