### PR TITLE
Enable gh npm publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,4 @@ jobs:
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: '--dry-run'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,14 +129,11 @@ jobs:
         with:
           name: generated-macos-latest
           path: generated
-      - uses: actions/setup-node@v1
-        with:
-          node-version: '13.x'
-          registry-url: 'https://registry.npmjs.org'
       - name: Publish to NPM
         uses: primer/publish@v2.0.0
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           args: '--dry-run'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,11 +133,10 @@ jobs:
         with:
           node-version: '13.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Publish (Debug)
+      - name: Publish to NPM
+        uses: primer/publish@v2.0.0
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          cat .npmrc || true
-          npm token list
-          ls -lR generated
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        with:
+          args: '--dry-run'
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webgpu",
   "main": "index.js",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "engines": {
     "node": ">= 13.0.0"
   },


### PR DESCRIPTION
I enabled the 'real' publish to NPM job.

See here for more info: https://github.com/primer/publish

It'll probably fail in my fork, because I don't have the correct NPM token.

Guess we'll only really know when merged to master :)